### PR TITLE
Use forwardPorts in dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
 {
 	"image": "node",
-	"appPort": 3000
+	"forwardPorts": ["localhost:3000"]
 }


### PR DESCRIPTION
This PR fixes an issue in the dev container where if a port was assigned different than 300 then the API calls would fail.

I replaced the `apport` with `forwardPorts` to ensure that the port 3000 was used in the host.